### PR TITLE
Improve error message when `.so` file without `.abi3.` in it is specified

### DIFF
--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -178,7 +178,6 @@ def main() -> None:
     )
     parser.add_argument(
         "specs",
-        type=make_specs,
         metavar="SPEC",
         nargs="+",
         help="the files or other dependency specs to scan",
@@ -230,12 +229,20 @@ def main() -> None:
     if args.debug:
         logging.root.setLevel("DEBUG")
 
+    specs = []
+    for spec in args.specs:
+        try:
+            specs.extend(make_specs(spec))
+        except InvalidSpec as e:
+            console.log(f"[red]:thumbs_down: processing error: {e}")
+            sys.exit(1)
+
     logger.debug(f"parsed arguments: {args}")
 
     results = SpecResults()
     all_passed = True
     with status:
-        for spec in itertools.chain.from_iterable(args.specs):
+        for spec in specs:
             status.update(f"auditing {spec}")
             try:
                 extractor = spec._extractor()

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -5,7 +5,6 @@ The `abi3audit` CLI.
 from __future__ import annotations
 
 import argparse
-import itertools
 import json
 import logging
 import os

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -20,6 +20,7 @@ from rich.logging import RichHandler
 from abi3audit._audit import AuditError, AuditResult, audit
 from abi3audit._extract import (
     Extractor,
+    ExtractorError,
     InvalidSpec,
     PyPISpec,
     SharedObjectSpec,
@@ -238,7 +239,7 @@ def main() -> None:
             status.update(f"auditing {spec}")
             try:
                 extractor = spec._extractor()
-            except InvalidSpec as e:
+            except ExtractorError as e:
                 console.log(f"[red]:thumbs_down: processing error: {e}")
                 sys.exit(1)
 

--- a/abi3audit/_extract.py
+++ b/abi3audit/_extract.py
@@ -104,7 +104,7 @@ def make_specs(val: str) -> list[Spec]:
         # audited (e.g. via an abi3 wheel), but not directly (since
         # without a tag here we don't know if it's abi3 at all).
         if ".abi3." not in val:
-            raise InvalidSpec(f"'{val}' looks like a shared object but is not tagged as abi3")
+            raise InvalidSpec(f"'{val}' must contain '.abi3.' to be recognized as a shared object")
         return [SharedObjectSpec(val)]
     elif re.match(_DISTRIBUTION_NAME_RE, val, re.IGNORECASE):
         return [PyPISpec(val)]

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -17,7 +17,7 @@ def test_make_spec():
     assert make_specs("foo") == [PyPISpec("foo")]
 
     # Shared objects need to be tagged with `.abi3`.
-    with pytest.raises(InvalidSpec):
+    with pytest.raises(InvalidSpec, match="'foo.so' must contain '.abi3.'"):
         make_specs("foo.so")
 
     # Anything that doesn't look like a wheel, shared object, or PyPI package fails.


### PR DESCRIPTION
This PR is mostly done to fix #117, but also improves another error message which I noticed while making it.

Unfortunately I don't know how to add tests for the CLI behaviour and there doesn't seem to be any existing ones, so I've only tested this manually but at least it does seem to work as expected:

```console
$ python -m abi3audit foo.so
[17:50:51] 👎 processing error: 'foo.so' must contain '.abi3.' to be recognized as a shared object
```