### PR TITLE
Use assumed ABI3 version for shared objects without ".abi3."

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -89,7 +89,7 @@ class AuditResult:
             yield f"[green]:thumbs_up: {self.so}"
 
 
-def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) -> AuditResult:
+def audit(so: SharedObject, assume_minimum_abi3: PyVersion = None) -> AuditResult:
     # We might fail to retrieve a minimum abi3 baseline if our context
     # (the shared object or its containing wheel) isn't actually tagged
     # as abi3 compatible.

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -89,7 +89,7 @@ class AuditResult:
             yield f"[green]:thumbs_up: {self.so}"
 
 
-def audit(so: SharedObject, assume_minimum_abi3: PyVersion = None) -> AuditResult:
+def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) -> AuditResult:
     # We might fail to retrieve a minimum abi3 baseline if our context
     # (the shared object or its containing wheel) isn't actually tagged
     # as abi3 compatible.

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -227,12 +227,10 @@ def main() -> None:
     if args.debug:
         logging.root.setLevel("DEBUG")
 
-    assume_minimum_abi3 = args.assume_minimum_abi3
-
     specs = []
     for spec in args.specs:
         try:
-            specs.extend(make_specs(spec, assume_minimum_abi3))
+            specs.extend(make_specs(spec, assume_minimum_abi3=args.assume_minimum_abi3))
         except InvalidSpec as e:
             console.log(f"[red]:thumbs_down: processing error: {e}")
             sys.exit(1)
@@ -254,7 +252,7 @@ def main() -> None:
                 status.update(f"{spec}: auditing {so}")
 
                 try:
-                    result = audit(so, assume_minimum_abi3)
+                    result = audit(so, assume_minimum_abi3=args.assume_minimum_abi3)
                     all_passed = all_passed and bool(result)
                 except AuditError as exc:
                     # TODO(ww): Refine exceptions and error states here.

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -220,7 +220,6 @@ def main() -> None:
     parser.add_argument(
         "--assume-minimum-abi3",
         action=_PyVersionAction,
-        default=PyVersion(3, 2),
         help="assumed abi3 version (3.x, with x>=2) if it cannot be detected",
     )
     args = parser.parse_args()
@@ -228,10 +227,12 @@ def main() -> None:
     if args.debug:
         logging.root.setLevel("DEBUG")
 
+    assume_minimum_abi3 = args.assume_minimum_abi3
+
     specs = []
     for spec in args.specs:
         try:
-            specs.extend(make_specs(spec))
+            specs.extend(make_specs(spec, assume_minimum_abi3))
         except InvalidSpec as e:
             console.log(f"[red]:thumbs_down: processing error: {e}")
             sys.exit(1)
@@ -253,7 +254,7 @@ def main() -> None:
                 status.update(f"{spec}: auditing {so}")
 
                 try:
-                    result = audit(so, assume_minimum_abi3=args.assume_minimum_abi3)
+                    result = audit(so, assume_minimum_abi3)
                     all_passed = all_passed and bool(result)
                 except AuditError as exc:
                     # TODO(ww): Refine exceptions and error states here.

--- a/abi3audit/_extract.py
+++ b/abi3audit/_extract.py
@@ -90,7 +90,7 @@ class PyPISpec(str):
 Spec = Union[WheelSpec, SharedObjectSpec, PyPISpec]
 
 
-def make_specs(val: str, assume_minimum_abi3: PyVersion = None) -> list[Spec]:
+def make_specs(val: str, assume_minimum_abi3: PyVersion | None = None) -> list[Spec]:
     """
     Constructs a (minimally) valid list of `Spec` instances from the given input.
     """
@@ -106,14 +106,16 @@ def make_specs(val: str, assume_minimum_abi3: PyVersion = None) -> list[Spec]:
         # only allow them if we have a minimum abi3 version to check against.
         if assume_minimum_abi3 is None and ".abi3." not in val:
             raise InvalidSpec(
-                f"'{val}' must contain '.abi3.' to be recognized as a shared "
-                + "object or assumed minimum ABI3 version must be specified"
+                "--assume-minimum-abi3 must be used when extension "
+                "does not contain '.abi3.' infix"
             )
         return [SharedObjectSpec(val)]
     elif re.match(_DISTRIBUTION_NAME_RE, val, re.IGNORECASE):
         return [PyPISpec(val)]
     else:
-        raise InvalidSpec(f"'{val}' does not look like a valid spec")
+        raise InvalidSpec(
+            f"'{val}' does not look like a valid wheel, shared object, or package name"
+        )
 
 
 class ExtractorError(ValueError):

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -32,7 +32,7 @@ class _SharedObjectBase:
         self._extractor = extractor
         self.path = self._extractor.path
 
-    def abi3_version(self, assume_lowest: PyVersion = PyVersion(3, 2)) -> PyVersion | None:
+    def abi3_version(self, assume_lowest: PyVersion) -> PyVersion | None:
         # If we're dealing with a shared object that was extracted from a wheel,
         # we try and suss out the abi3 version from the wheel's own tags.
         if self._extractor.parent is not None:
@@ -50,14 +50,18 @@ class _SharedObjectBase:
         # filename. This doesn't tell us anything about the specific abi3 version, so
         # we assume the lowest.
         if ".abi3" in self._extractor.path.suffixes:
+            if assume_lowest is None:
+                assume_lowest = PyVersion(3, 2)
+
             logger.debug(
                 "no wheel to infer abi3 version from; assuming (%s)",
                 assume_lowest,
             )
             return assume_lowest
 
-        # With no wheel tags and no filename tag, we have nothing to go on.
-        return None
+        # With no wheel tags and no filename tag, fall back on the assumed ABI
+        # version (which is possibly None).
+        return assume_lowest
 
     def __str__(self) -> str:
         parents = []

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -1,4 +1,5 @@
 import pytest
+from abi3info.models import PyVersion
 
 from abi3audit._extract import (
     ExtractorError,
@@ -16,9 +17,12 @@ def test_make_spec():
     assert make_specs("foo.abi3.so") == [SharedObjectSpec("foo.abi3.so")]
     assert make_specs("foo") == [PyPISpec("foo")]
 
-    # Shared objects need to be tagged with `.abi3`.
-    with pytest.raises(InvalidSpec, match="'foo.so' must contain '.abi3.'"):
+    # Shared objects need to be tagged with `.abi3` or --assume-minimum-abi3
+    # must be used.
+    with pytest.raises(InvalidSpec, match="--assume-minimum-abi3"):
         make_specs("foo.so")
+
+    make_specs("foo.so", assume_minimum_abi3=PyVersion(3, 2)) == [SharedObjectSpec("foo.so")]
 
     # Anything that doesn't look like a wheel, shared object, or PyPI package fails.
     with pytest.raises(InvalidSpec):


### PR DESCRIPTION
Allow auditing arbitrary shared objects, not necessarily containing ".abi3." in their name, if --assume-minimum-abi3 option is specified: suppose that all shared objects use this ABI3 version then.

This makes the tool more convenient to use for non-wheel-packaged extensions.

Also specify the default, 3.2, ABI version in a single place only and use "None" instead of the default value elsewhere.

----

Sorry, I couldn't prevent myself from making this PR, implementing the suggestion discussed in #117. This may address #116 too, but mostly it makes the tool much more convenient for me to use, as I don't have to rename all the files (or create symlinks for them) before running it on them.