### PR TITLE
Make `--verbose` imply `--summary` on the command line

### DIFF
--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -267,7 +267,7 @@ def main() -> None:
                 if not result and args.verbose:
                     console.log(result)
 
-            log_message = results.summarize_extraction(extractor, args.summary)
+            log_message = results.summarize_extraction(extractor, args.summary or args.verbose)
             if log_message:
                 console.log(log_message)
 


### PR DESCRIPTION
This is more in line with user expectations, and results in tables being rendered when invoking `abi3audit <spec> -v`, even without `--summary`.

`--summary` behavior itself is unchanged, as is the rendering algorithm.

---------------------

On the other feature branch, testing on Dockerfile v3.3.1, CPython 3.8, manylinux, this results in:

```
$ abi3audit wheelhouse/dockerfile-3.3.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl -v   
[19:55:27] 👎 dockerfile-3.3.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl: dockerfile.abi3.so has non-ABI3 symbols                                                    
           ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓                                                                                                                       
           ┃ Symbol                          ┃ Version  ┃                                                                                                                       
           ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩                                                                                                                       
           │ PyDockerfile_GoIOError          │ not ABI3 │                                                                                                                       
           │ PyDockerfile_PyArg_ParseTuple_U │ not ABI3 │                                                                                                                       
           │ PyDockerfile_Command            │ not ABI3 │                                                                                                                       
           │ PyDockerfile_GoParseError       │ not ABI3 │                                                                                                                       
           │ PyDockerfile_Py_RETURN_NONE     │ not ABI3 │                                                                                                                       
           │ PyDockerfile_NewCommand         │ not ABI3 │                                                                                                                       
           └─────────────────────────────────┴──────────┘                                                                                                                       
           💁 dockerfile-3.3.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl: 1 extensions scanned; 0 ABI version mismatches and 6 ABI violations found
``` 