### PR TITLE
Allow general requirements as PyPISpec inputs

### DIFF
--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -26,7 +26,7 @@ def test_make_spec():
 
     # Anything that doesn't look like a wheel, shared object, or PyPI package fails.
     with pytest.raises(InvalidSpec):
-        make_specs("foo@foo")
+        make_specs("foo?")
 
 
 class TestWheelExtractor:


### PR DESCRIPTION
Requirements are processed as dictated by `packaging.requirements.Requirement`.

In essence, this also allows auditing a pinned requirements.txt file as generated e.g. by `uv pip compile`.

Caveat: Only PyPI URLs are audited, no custom indexes / git dependencies are supported.

----------------------------

A CLI test on this branch:

```
$ abi3audit -v "google-benchmark>=1.8.0,<2"
[10:41:20] 💁 google-benchmark>=1.8.0,<2: 5 extensions scanned; 0 ABI version mismatches and 0 ABI violations found 
```

Requirement errors are given as hints to the processing error:

```
$ abi3audit -v "google-benchm?rk>=1.8.0,<2"
[10:42:51] 👎 processing error: 'google-benchm?rk>=1.8.0,<2' does not look like a valid wheel, shared object, or package name                                                   
           hint: Expected end or semicolon (after name and no valid version specifier)                                                                                          
               google-benchm?rk>=1.8.0,<2                                                                                                                                       
                            ^ 
```