### PR TITLE
audit: add Py_TYPE to allowed symbols list

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 _ALLOWED_SYMBOLS: set[str] = {
     "Py_XDECREF",  # not stable ABI, but defined as static inline in limited API
     "Py_TYPE",  # static inline before 3.14, stable ABI since 3.14
+    "Py_REFCNT",  # macro before 3.11, static inline before 3.14, stable ABI since 3.14
 }
 
 

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 # Since they are not listed in CPython's `stable_abi.toml`, we maintain them here separately.
 # For more information, see https://github.com/pypa/abi3audit/issues/85
 # and https://github.com/wjakob/nanobind/discussions/500 .
-_ALLOWED_SYMBOLS: set[str] = {"Py_XDECREF"}
+_ALLOWED_SYMBOLS: set[str] = {
+    "Py_XDECREF",  # not stable ABI, but defined as static inline in limited API
+    "Py_TYPE",  # static inline before 3.14, stable ABI since 3.14
+}
 
 
 class AuditError(Exception):


### PR DESCRIPTION
Not technically part of the stable ABI until
3.14, but is defined as `static inline` when
used with the limited API and therefore
exhibits the same indirect ABI compatibility
behavior as `Py_XDECREF`.

~~NB: I haven't done anything with `Py_NewRef`/`_Py_NewRef`
yet, pending clarification on #137.~~

Closes #137.