### PR TITLE
The assumed ABI version is possibly `None`

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -96,10 +96,12 @@ class AuditResult:
             yield f"[green]:thumbs_up: {self.so}"
 
 
-def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) -> AuditResult:
+def audit(so: SharedObject, assume_minimum_abi3: PyVersion | None = None) -> AuditResult:
     # We might fail to retrieve a minimum abi3 baseline if our context
     # (the shared object or its containing wheel) isn't actually tagged
     # as abi3 compatible.
+    if assume_minimum_abi3 is None:
+        assume_minimum_abi3 = PyVersion(3, 2)
     baseline = so.abi3_version(assume_lowest=assume_minimum_abi3)
     if baseline is None:
         raise AuditError("failed to determine ABI version baseline: not abi3 tagged?")

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -32,7 +32,7 @@ class _SharedObjectBase:
         self._extractor = extractor
         self.path = self._extractor.path
 
-    def abi3_version(self, assume_lowest: PyVersion) -> PyVersion | None:
+    def abi3_version(self, assume_lowest: PyVersion | None) -> PyVersion | None:
         # If we're dealing with a shared object that was extracted from a wheel,
         # we try and suss out the abi3 version from the wheel's own tags.
         if self._extractor.parent is not None:


### PR DESCRIPTION
https://github.com/pypa/abi3audit/blob/ca87d3a059bbdde7d97904996ba60a36529d27e5/abi3audit/_object.py#L62-L63