### PR TITLE
Apply ruff/flake8-bugbear rule B904

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -137,6 +137,6 @@ def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) ->
                 if sym not in _ALLOWED_SYMBOLS and sym.visibility != "local":
                     non_abi3_symbols.add(sym)
     except Exception as exc:
-        raise AuditError(f"failed to collect symbols in shared object: {exc}")
+        raise AuditError(f"failed to collect symbols in shared object: {exc}") from exc
 
     return AuditResult(so, baseline, computed, non_abi3_symbols, future_abi3_objects)

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -71,7 +71,7 @@ class _PyVersionAction(argparse.Action):
         try:
             pyversion = self._ensure_pyversion(values)
         except ValueError as exc:
-            raise argparse.ArgumentError(self, str(exc))
+            raise argparse.ArgumentError(self, str(exc)) from exc
         setattr(namespace, self.dest, pyversion)
 
     @classmethod
@@ -79,8 +79,8 @@ class _PyVersionAction(argparse.Action):
         error_msg = f"must have syntax '3.x', with x>=2; you gave '{version}'"
         try:
             pyversion = PyVersion.parse_dotted(version)
-        except Exception:
-            raise ValueError(error_msg)
+        except Exception as exc:
+            raise ValueError(error_msg) from exc
         if pyversion.major != 3 or pyversion.minor < 2:
             raise ValueError(error_msg)
         return pyversion

--- a/abi3audit/_extract.py
+++ b/abi3audit/_extract.py
@@ -117,7 +117,7 @@ def make_specs(val: str, assume_minimum_abi3: PyVersion | None = None) -> list[S
             raise InvalidSpec(
                 f"'{val}' does not look like a valid wheel, shared object, or package name\n"
                 f"hint: {e}"
-            )
+            ) from e
 
 
 class ExtractorError(ValueError):

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -135,7 +135,7 @@ class _Dylib(_SharedObjectBase):
         try:
             with mach_o.MachO.from_file(self._extractor.path) as macho:
                 yield macho
-        except Exception:
+        except Exception as exc:
             logger.debug(f"mach-o decode for {self._extractor.path} failed; trying as a fat mach-o")
             # To handle "fat" Mach-Os, we do some ad-hoc parsing below:
             # * Check that we're really in a fat Mach-O and, if
@@ -155,7 +155,7 @@ class _Dylib(_SharedObjectBase):
                     # Mach-O Fat headers, but they never appear in the wild.
                     raise SharedObjectError(
                         f"bad magic: {hex(magic)} (not FAT_MAGIC or FAT_MAGIC_64)"
-                    )
+                    ) from exc
 
                 (nfat_arch,) = struct.unpack(fieldspec[0], io.read(fieldspec[1]))
                 for _ in range(nfat_arch):


### PR DESCRIPTION
B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling