### PR TITLE
Enforce more ruff rules

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -94,12 +94,10 @@ class AuditResult:
             yield f"[green]:thumbs_up: {self.so}"
 
 
-def audit(so: SharedObject, assume_minimum_abi3: PyVersion | None = None) -> AuditResult:
+def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) -> AuditResult:
     # We might fail to retrieve a minimum abi3 baseline if our context
     # (the shared object or its containing wheel) isn't actually tagged
     # as abi3 compatible.
-    if assume_minimum_abi3 is None:
-        assume_minimum_abi3 = PyVersion(3, 2)
     baseline = so.abi3_version(assume_lowest=assume_minimum_abi3)
     if baseline is None:
         raise AuditError("failed to determine ABI version baseline: not abi3 tagged?")

--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -94,10 +94,12 @@ class AuditResult:
             yield f"[green]:thumbs_up: {self.so}"
 
 
-def audit(so: SharedObject, assume_minimum_abi3: PyVersion = PyVersion(3, 2)) -> AuditResult:
+def audit(so: SharedObject, assume_minimum_abi3: PyVersion | None = None) -> AuditResult:
     # We might fail to retrieve a minimum abi3 baseline if our context
     # (the shared object or its containing wheel) isn't actually tagged
     # as abi3 compatible.
+    if assume_minimum_abi3 is None:
+        assume_minimum_abi3 = PyVersion(3, 2)
     baseline = so.abi3_version(assume_lowest=assume_minimum_abi3)
     if baseline is None:
         raise AuditError("failed to determine ABI version baseline: not abi3 tagged?")

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -228,12 +228,12 @@ def main() -> None:
         logging.root.setLevel("DEBUG")
 
     specs = []
-    for spec in args.specs:
-        try:
+    try:
+        for spec in args.specs:
             specs.extend(make_specs(spec, assume_minimum_abi3=args.assume_minimum_abi3))
-        except InvalidSpec as e:
-            console.log(f"[red]:thumbs_down: processing error: {e}")
-            sys.exit(1)
+    except InvalidSpec as e:
+        console.log(f"[red]:thumbs_down: processing error: {e}")
+        sys.exit(1)
 
     logger.debug(f"parsed arguments: {args}")
 

--- a/abi3audit/_cli.py
+++ b/abi3audit/_cli.py
@@ -126,7 +126,7 @@ class SpecResults:
         # TODO(ww): These inner helpers could definitely be consolidated.
         def _one_object(results: list[AuditResult]) -> dict[str, Any]:
             # NOTE: Anything else indicates a logic error.
-            assert len(results) == 1
+            assert len(results) == 1  # noqa: S101
             return {"name": results[0].so.path.name, "result": results[0].json()}
 
         def _one_wheel(results: list[AuditResult]) -> list[dict[str, Any]]:

--- a/abi3audit/_extract.py
+++ b/abi3audit/_extract.py
@@ -40,8 +40,6 @@ class InvalidSpec(ValueError):
     specification into something that can be extracted.
     """
 
-    pass
-
 
 class WheelSpec(str):
     """
@@ -130,8 +128,6 @@ class ExtractorError(ValueError):
     Raised when abi3audit doesn't know how to (or can't) extract shared objects
     from the requested source.
     """
-
-    pass
 
 
 class WheelExtractor:

--- a/abi3audit/_extract.py
+++ b/abi3audit/_extract.py
@@ -50,6 +50,8 @@ class WheelSpec(str):
     A wheel can contain multiple Python extensions, as shared objects.
     """
 
+    __slots__ = ()
+
     def _extractor(self) -> Extractor:
         """
         Returns an extractor for this wheel's shared objects.
@@ -63,6 +65,8 @@ class SharedObjectSpec(str):
 
     A shared object may or may not be a Python extension.
     """
+
+    __slots__ = ()
 
     def _extractor(self) -> Extractor:
         """
@@ -78,6 +82,8 @@ class PyPISpec(str):
     A package may have zero or more published wheels, of which zero or more
     may be tagged as abi3 compatible.
     """
+
+    __slots__ = ()
 
     def _extractor(self) -> Extractor:
         """

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -32,7 +32,7 @@ class _SharedObjectBase:
         self._extractor = extractor
         self.path = self._extractor.path
 
-    def abi3_version(self, assume_lowest: PyVersion) -> PyVersion | None:
+    def abi3_version(self, assume_lowest: PyVersion | None) -> PyVersion | None:
         # If we're dealing with a shared object that was extracted from a wheel,
         # we try and suss out the abi3 version from the wheel's own tags.
         if self._extractor.parent is not None:

--- a/abi3audit/_object.py
+++ b/abi3audit/_object.py
@@ -32,7 +32,7 @@ class _SharedObjectBase:
         self._extractor = extractor
         self.path = self._extractor.path
 
-    def abi3_version(self, assume_lowest: PyVersion | None) -> PyVersion | None:
+    def abi3_version(self, assume_lowest: PyVersion) -> PyVersion | None:
         # If we're dealing with a shared object that was extracted from a wheel,
         # we try and suss out the abi3 version from the wheel's own tags.
         if self._extractor.parent is not None:
@@ -59,8 +59,7 @@ class _SharedObjectBase:
             )
             return assume_lowest
 
-        # With no wheel tags and no filename tag, fall back on the assumed ABI
-        # version (which is possibly None).
+        # With no wheel tags and no filename tag, fall back on the assumed ABI version.
         return assume_lowest
 
     def __str__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ omit = ["abi3audit/_vendor/*"]
 
 [tool.ruff]
 line-length = 100
+exclude = ["abi3audit/_vendor"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "UP"]
+select = ["E", "F", "I", "W", "B", "A", "C4", "EXE", "FA", "ISC", "ICN", "LOG", "PIE", "PYI", "SLOT", "FLY", "PERF", "PGH", "PL", "FURB", "UP"]
+ignore = ["PLR1730", "PLR2004"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Source = "https://github.com/pypa/abi3audit"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
-lint = ["bandit", "interrogate", "mypy", "ruff", "types-requests"]
+lint = ["interrogate", "mypy", "ruff", "types-requests"]
 dev = ["build", "pdoc3", "abi3audit[test,lint]"]
 
 [project.scripts]
@@ -64,9 +64,6 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
-[tool.bandit]
-exclude_dirs = ["./test"]
-
 [tool.coverage.run]
 omit = ["abi3audit/_vendor/*"]
 
@@ -75,5 +72,8 @@ line-length = 100
 exclude = ["abi3audit/_vendor"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "B", "A", "C4", "EXE", "FA", "ISC", "ICN", "LOG", "PIE", "PYI", "SLOT", "FLY", "PERF", "PGH", "PL", "FURB", "UP"]
+select = ["E", "F", "I", "W", "S", "B", "A", "C4", "EXE", "FA", "ISC", "ICN", "LOG", "PIE", "PYI", "SLOT", "FLY", "PERF", "PGH", "PL", "FURB", "UP"]
 ignore = ["PLR1730", "PLR2004"]
+
+[tool.ruff.lint.per-file-ignores]
+"test/**.py" = ["S101", "S113"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,8 @@ exclude = ["abi3audit/_vendor"]
 select = ["E", "F", "I", "W", "S", "B", "A", "C4", "EXE", "FA", "ISC", "ICN", "LOG", "PIE", "PYI", "SLOT", "FLY", "PERF", "PGH", "PL", "FURB", "UP"]
 ignore = ["PLR1730", "PLR2004"]
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["abi3info.models.PyVersion"]
+
 [tool.ruff.lint.per-file-ignores]
 "test/**.py" = ["S101", "S113"]

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "bandit" },
     { name = "build" },
     { name = "coverage", extra = ["toml"] },
     { name = "interrogate" },
@@ -35,7 +34,6 @@ dev = [
     { name = "types-requests" },
 ]
 lint = [
-    { name = "bandit" },
     { name = "interrogate" },
     { name = "mypy" },
     { name = "ruff" },
@@ -52,7 +50,6 @@ test = [
 requires-dist = [
     { name = "abi3audit", extras = ["test", "lint"], marker = "extra == 'dev'" },
     { name = "abi3info", specifier = ">=2024.6.19" },
-    { name = "bandit", marker = "extra == 'lint'" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'" },
     { name = "interrogate", marker = "extra == 'lint'" },
@@ -89,21 +86,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
-]
-
-[[package]]
-name = "bandit"
-version = "1.8.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is why I assume the ABI version could be `None`:
https://github.com/pypa/abi3audit/blob/ca87d3a059bbdde7d97904996ba60a36529d27e5/abi3audit/_object.py#L62-L63