### PR TITLE
Fix Py_XDECREF

### DIFF
--- a/abi3audit/_audit.py
+++ b/abi3audit/_audit.py
@@ -21,11 +21,9 @@ logger = logging.getLogger(__name__)
 # A handpicked exclusion list of symbols that are not strictly in the limited API
 # or stable ABI, but in practice always appear in ABI3-compatible code.
 # Since they are not listed in CPython's `stable_abi.toml`, we maintain them here separately.
-# For more information, see https://github.com/pypa/abi3audit/issues/85
-# and https://github.com/wjakob/nanobind/discussions/500 .
-_ALLOWED_SYMBOLS: set[str] = {
-    "Py_XDECREF",  # not stable ABI, but defined as static inline in limited API
-}
+# The list of symbols is currently empty. Any `static inline` function from Python headers
+# may produce a local symbol which does not affect ABI3 compatibility.
+_ALLOWED_SYMBOLS: set[str] = set()
 
 
 class AuditError(Exception):

--- a/test/test_audit_unit.py
+++ b/test/test_audit_unit.py
@@ -49,22 +49,13 @@ shared_objects = [
         ],
     ),
     SharedObject(
-        baseline=PyVersion(3, 10),
-        computed=PyVersion(3, 10),
-        symbols=[
-            Symbol("PyType_GetModule", "global"),
-            # This test is just to assert the existing behaviour. Py_XDECREF is never a global
-            # symbol and will always be local.
-            Symbol("Py_XDECREF", "global"),
-        ],
-    ),
-    SharedObject(
         baseline=PyVersion(3, 9),
         computed=PyVersion(3, 14),
         symbols=[
             Symbol("PyType_GetModule", "global"),
             Symbol("Py_TYPE", "global"),
             Symbol("Py_REFCNT", "local"),
+            Symbol("Py_XDECREF", "local"),
         ],
         future_abi3_objects=[
             Function(

--- a/test/test_audit_unit.py
+++ b/test/test_audit_unit.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 import pytest
 from abi3info.models import Function, PyVersion, Symbol
 
+from abi3audit._audit import _ALLOWED_SYMBOLS as ALLOWED_SYMBOLS
 from abi3audit._audit import audit
 
 
@@ -81,12 +82,24 @@ shared_objects = [
             Symbol("Py_foo_bar", None),
         ],
     ),
+    SharedObject(
+        baseline=PyVersion(3, 10),
+        computed=PyVersion(3, 10),
+        symbols=[
+            Symbol("PyType_GetModule", "global"),
+            Symbol("Py_abi3audit_allowed_symbol", "global"),
+        ],
+    ),
 ]
 
 
 @pytest.mark.parametrize("so", shared_objects)
 def test_audit_result_unit_test(so):
-    result = audit(so, so.baseline)
+    ALLOWED_SYMBOLS.add("Py_abi3audit_allowed_symbol")
+    try:
+        result = audit(so, so.baseline)
+    finally:
+        ALLOWED_SYMBOLS.remove("Py_abi3audit_allowed_symbol")
     assert result.baseline == so.baseline
     assert result.computed == so.computed
     assert result.future_abi3_objects == set(so.future_abi3_objects)


### PR DESCRIPTION
After the changes in #164, listing `Py_XDECREF` as an allowed symbol is no longer necessary. `Py_XDECREF` is `static inline` and if a symbol is produced (depending on C compiler optimization), it is a local symbol.

With this PR, the current list of allowed symbols becomes empty. I was not sure whether to remove it or keep it in case it is needed in the future. I sided for the second option and added a test (using some monkeypatching, hope that's OK). If you guys feel otherwise, then I can drop the last commit and push a new one removing the `_ALLOWED_SYMBOLS` list.

cc @isuruf for viz as the author of #164